### PR TITLE
Fix: dock shows when tooltips and dropdowns are open

### DIFF
--- a/dock-dodge.applescript
+++ b/dock-dodge.applescript
@@ -8,7 +8,7 @@ on GetWindowLocation()
 		set activeApps to name of application processes whose frontmost is true
 		set currentApplication to item 1 of activeApps
 		try
-			set frontWindow to the first window of application process currentApplication
+			set frontWindow to the first window of application process currentApplication whose role description is "standard window"
 			set windowSize to size of frontWindow
 			set windowPosition to position of frontWindow
 			return (item 2 of windowSize) + (item 2 of windowPosition)


### PR DESCRIPTION
Tooltips and select dropdowns are considered separate windows of the application, thus the script used them to calculate the position of the application, which it should not. this fixes it by excluding special windows when trying to find the active window position.